### PR TITLE
Support for new reporting

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,7 +15,7 @@ services:
     restart: on-failure
     entrypoint: node_modules/.bin/gulp
     environment:
-      ACCOUNT_KEY: dev-tenant
+      ACCOUNT_KEY: ${ACCOUNT_KEY-dev-tenant}
       BASE_URI: localhost:8100
       DEBUG: ${DEBUG}
       ELASTIC_HOST: http://elasticsearch:9200

--- a/src/graph/definitions/report.graphql
+++ b/src/graph/definitions/report.graphql
@@ -25,10 +25,7 @@ type CampaignCreativeBreakdown {
 }
 
 type CreativeSummary {
-  id: String!
-  title: String
-  teaser: String
-  # image: Image
+  creative: CampaignCreative
   views: Int!
   clicks: Int!
   ctr: Float!

--- a/src/services/reporting.js
+++ b/src/services/reporting.js
@@ -37,9 +37,9 @@ const getCtrProject = () => ({
 });
 
 module.exports = {
-  async campaignSummary(hash) {
-    const campaign = await Campaign.findOne({ hash });
-    if (!campaign) throw new Error(`No campaign record found for hash '${hash}'`);
+  async campaignSummary(pushId) {
+    const campaign = await Campaign.findOne({ pushId });
+    if (!campaign) throw new Error(`No campaign record found for pushId '${pushId}'`);
     const cid = campaign.get('id');
     const start = moment(campaign.get('criteria.start')).startOf('day');
     const end = campaign.get('criteria.end')
@@ -109,9 +109,9 @@ module.exports = {
     out.days = dates.map(d => fillDayData(d, out.days));
     return out;
   },
-  async campaignCreativeBreakdown(hash) {
-    const campaign = await Campaign.findOne({ hash });
-    if (!campaign) throw new Error(`No campaign record found for hash '${hash}'`);
+  async campaignCreativeBreakdown(pushId) {
+    const campaign = await Campaign.findOne({ pushId });
+    if (!campaign) throw new Error(`No campaign record found for pushId '${pushId}'`);
     const cid = campaign.get('id');
     const creatives = campaign.get('creatives');
     const creativeIds = [];
@@ -221,7 +221,7 @@ module.exports = {
     ];
     const results = await Analytics.aggregate(pipeline);
     const out = results[0];
-    if (!out) throw new Error(`No results found for hash '${hash}'`);
+    if (!out) throw new Error(`No results found for pushId '${pushId}'`);
     const dates = createDateRange(start, end);
     for (let i = 0; i < out.creatives.length; i += 1) {
       const id = out.creatives[i]._id;

--- a/src/services/reporting.js
+++ b/src/services/reporting.js
@@ -225,9 +225,7 @@ module.exports = {
     const dates = createDateRange(start, end);
     for (let i = 0; i < out.creatives.length; i += 1) {
       const id = out.creatives[i]._id;
-      out.creatives[i].title = creativesById[id].title;
-      out.creatives[i].teaser = creativesById[id].teaser;
-      out.creatives[i].image = creativesById[id].image;
+      out.creatives[i].creative = creativesById[id];
       out.creatives[i].days = dates.map(d => fillDayData(d, out.creatives[i].days));
     }
     return out;


### PR DESCRIPTION
Retrieves campaigns by `pushId` instead of `hash`, returns the `CampaignCreative` definition inside the `CreativeSummary`, and adds support for setting `ACCOUNT_KEY` in the `.env` file.